### PR TITLE
Make example actually create output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .vscode
 dist
 .idea
+ts2graphql.code-workspace

--- a/example/test.ts
+++ b/example/test.ts
@@ -43,3 +43,7 @@ interface Baz {
         foo?: number;
     }): Bar;
 }
+
+interface Query {
+    mainQuery: MainQuery;
+}

--- a/src/createSchema.ts
+++ b/src/createSchema.ts
@@ -60,6 +60,7 @@ export function createSchema(
                 }
             }
         }
+        if (!(query||mutation)) throw new Error("No 'Query' or 'Mutation' type found");
         return new GraphQLSchema({
             query: query,
             mutation: mutation,
@@ -106,7 +107,7 @@ export function createSchema(
 
     function createGQLType(type: Interface | InterfaceLiteral, isInput: boolean): GraphQLType {
         let typeName = type.kind === 'interface' ? type.name : '';
-        const Class = isInput ? (GraphQLInputObjectType as typeof GraphQLObjectType) : GraphQLObjectType;
+        const Class = isInput ? (GraphQLInputObjectType as unknown as typeof GraphQLObjectType) : GraphQLObjectType;
 
         const fields = {} as GraphQLFieldConfigMap<{}, {}>;
         if (type.kind === 'interfaceLiteral') {
@@ -129,9 +130,9 @@ export function createSchema(
         });
         add(type, gqlType);
         type.members.reduce((obj, member) => {
-            if (member.orUndefined) throw new Error('Undefined props are not supported in graphql');
+            // if (member.orUndefined) throw new Error('Undefined props are not supported in graphql');
             const memberType = {
-                type: nullable(member.orNull, createGQL(member.type, false)) as GraphQLOutputType,
+                type: nullable(member.orNull||member.orUndefined, createGQL(member.type, false)) as GraphQLOutputType,
                 args:
                     member.args && member.args.length === 1
                         ? (member.args[0].type as InterfaceLiteral).members.reduce(


### PR DESCRIPTION
This may not be the best method to fix this, but as-is, it first dies with
⨯ Unable to compile TypeScript:
src/createSchema.ts(109,34): error TS2352: Conversion of type 'typeof GraphQLInputObjectType' to type 'typeof GraphQLObjectType' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Type 'GraphQLInputObjectType' is missing the following properties from type 'GraphQLObjectType<any, any>': isTypeOf, getInterfaces
and after fixing that, produces no output because there is no Query defined (missing an error message), and then it gets upset at ?-types.